### PR TITLE
Set up deployment to Heroku

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,17 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: akhileshns/heroku-deploy@v3.12.12
+        with:
+          heroku_api_key: ${{secrets.HEROKU_API_KEY}}
+          heroku_app_name: "readlist-app"
+          heroku_email: "mail@huwdiprose.co.uk"
+          usedocker: true


### PR DESCRIPTION
Github actions comes built in with github, making it a convenient choice
for a quick CI setup.

Initially we just want a single job to deploy the app. I have stepped
through the [guide here][1] taking most of the first deploy example.

In addition we want to try and deplo with docker, so I've added the
line:
`usedocker: true`

The credentials themselves were input manually so cannot be reviewed in
this PR.

I used a pre-existing hobby [heroku account][2], using my credentails (a
heroku API KEY) and email.

The API KEY was put into github secrets, where it should be secure but
accessible to Github's CI.

[1]: https://github.com/marketplace/actions/deploy-to-heroku
[2]: https://signup.heroku.com/